### PR TITLE
Fix mobile timeline scroll

### DIFF
--- a/style_v13.css
+++ b/style_v13.css
@@ -390,8 +390,15 @@ footer {
 
 .timeline-events-wrapper {
     flex-grow: 1;
-    overflow-x: hidden; /* Hide scrollbar */
+    overflow-x: auto; /* Allow horizontal scroll */
     margin: 0 15px;
+    -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
+    -ms-overflow-style: none; /* Hide scrollbar on IE and Edge */
+    scrollbar-width: none; /* Hide scrollbar on Firefox */
+}
+
+.timeline-events-wrapper::-webkit-scrollbar {
+    display: none; /* Hide scrollbar on WebKit */
 }
 
 .timeline-events-inner {


### PR DESCRIPTION
## Summary
- make timeline horizontally scrollable on mobile by using `overflow-x: auto`
- hide the scrollbar while preserving touch-friendly scrolling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875f4b93d58832a95a62b0ab5e599db